### PR TITLE
Responsify Select Dish page

### DIFF
--- a/styling/css/style.css
+++ b/styling/css/style.css
@@ -103,25 +103,27 @@ a {
   margin-top: 32px; }
 
 .dish-items-wrapper {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 140px);
+  grid-gap: 1rem;
   justify-content: space-between; }
   .dish-items-wrapper a {
-    position: relative;
-    margin-bottom: 64px; }
+    margin-bottom: 64px;
+    max-width: 140px; }
     .dish-items-wrapper a img {
       border: 3px solid #000000;
-      border-bottom: none; }
+      border-bottom: none;
+      min-height: 100%;
+      max-width: 100%; }
     .dish-items-wrapper a h3 {
-      position: absolute;
-      display: flex;
-      justify-content: center;
-      align-items: center;
       background: #E5E5E5;
       font-size: 14px;
       border: 3px solid #000000;
       padding: 4px;
-      width: 100%; }
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: center; }
 
 #dinnerOverviewView {
   display: flex;
@@ -204,8 +206,11 @@ h1 {
 
 .select-dish {
   display: flex;
-  flex-direction: row;
-  padding-top: 24px; }
+  padding-top: 24px;
+  flex-direction: column; }
+  @media (min-width: 576px) {
+    .select-dish {
+      flex-direction: row; } }
 
 #sideBarView {
   display: flex;
@@ -216,7 +221,7 @@ h1 {
   #sideBarView h2 {
     margin-top: 8px; }
   #sideBarView > button {
-    margin-bottom: 8px; }
+    margin: 24px 0 16px; }
   #sideBarView ul {
     list-style: none;
     padding: 0; }
@@ -246,9 +251,24 @@ h1 {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 15px; }
+    height: 15px;
+    border: none;
+    box-shadow: none; }
   .up-down-buttons .btn {
     padding: 0; }
+
+.side-bar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center; }
+  .side-bar-header .fa {
+    font-size: 25px; }
+  .side-bar-header .fa-bars {
+    display: none; }
+  @media (min-width: 576px) {
+    .side-bar-header .fa-times,
+    .side-bar-header .fa-bars {
+      display: none; } }
 
 .side-bar-sub-header {
   width: calc(100% + 30px);
@@ -270,7 +290,12 @@ h1 {
   align-self: end; }
 
 #dishSearchView {
-  padding-left: 32px; }
+  padding: 0;
+  margin-top: 32px; }
+  @media (min-width: 576px) {
+    #dishSearchView {
+      padding-left: 32px;
+      margin-top: 0; } }
 
 .search-bar {
   border: 4px solid #000000;
@@ -278,16 +303,26 @@ h1 {
   .search-bar h2 {
     margin-top: 8px; }
   .search-bar .search-bar-container {
-    margin-bottom: 10px; }
+    margin-bottom: 16px; }
 
 #keywordInput,
-#dishTypeSelect,
-#searchDishButton {
+#dishTypeSelect {
   background: none;
   border: 3px solid #000000;
   padding-left: 16px;
   margin-right: 16px;
   height: 32px; }
+
+#searchDishButton {
+  height: 32px;
+  padding: 0 16px;
+  margin-top: -4px; }
+
+#keywordInput {
+  margin-bottom: 8px; }
+  @media (min-width: 576px) {
+    #keywordInput {
+      margin-bottom: 0; } }
 
 #prepSection {
   margin-top: 32px;

--- a/styling/sass/includes/components/_dish-item.scss
+++ b/styling/sass/includes/components/_dish-item.scss
@@ -3,29 +3,31 @@
 }
 
 .dish-items-wrapper {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 140px);
+  grid-gap: 1rem;
   justify-content: space-between;
 
   a {
-    position: relative;
     margin-bottom: $padding-xl;
+    max-width: 140px;
 
     img {
       border: 3px solid $black;
       border-bottom: none;
+      min-height: 100%;
+      max-width: 100%;
     }
 
     h3 {
-      position: absolute;
-      display: flex;
-      justify-content: center;
-      align-items: center;
       background: $grey;
       font-size: 14px;
       border: 3px solid $black;
       padding: 4px;
-      width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: center;
     }
   }
 }

--- a/styling/sass/includes/components/_search-bar.scss
+++ b/styling/sass/includes/components/_search-bar.scss
@@ -1,5 +1,11 @@
 #dishSearchView {
-  padding-left: $padding-md;
+  padding: 0;
+  margin-top: $padding-md;
+
+  @include media-breakpoint-up(sm) {
+    padding-left: $padding-md;
+    margin-top: 0;
+  }
 }
 
 .search-bar {
@@ -11,16 +17,29 @@
   }
 
   .search-bar-container {
-    margin-bottom: 10px;
+    margin-bottom: $padding-xs;
   }
 }
 
 #keywordInput,
-#dishTypeSelect,
-#searchDishButton {
+#dishTypeSelect {
   background: none;
   border: 3px solid $black;
   padding-left: $padding-xs;
   margin-right: $padding-xs;
   height: 32px;
+}
+
+#searchDishButton {
+  height: 32px;
+  padding: 0 $padding-xs;
+  margin-top: -4px;
+}
+
+#keywordInput {
+  margin-bottom: $padding-xxs;
+
+  @include media-breakpoint-up(sm) {
+    margin-bottom: 0;
+  }
 }

--- a/styling/sass/includes/components/_select-dish.scss
+++ b/styling/sass/includes/components/_select-dish.scss
@@ -1,5 +1,9 @@
 .select-dish {
   display: flex;
-  flex-direction: row;
   padding-top: $padding-sm;
+  flex-direction: column;
+
+  @include media-breakpoint-up(sm) {
+    flex-direction: row;
+  }
 }

--- a/styling/sass/includes/components/_side-bar.scss
+++ b/styling/sass/includes/components/_side-bar.scss
@@ -10,7 +10,7 @@
   }
 
   > button {
-    margin-bottom: $padding-xxs;
+    margin: $padding-sm 0 $padding-xs;
   }
 
   ul {
@@ -50,6 +50,8 @@
     justify-content: center;
     align-items: center;
     height: 15px;
+    border: none;
+    box-shadow: none;
   }
 
   .btn {
@@ -57,6 +59,26 @@
   }
 }
 
+.side-bar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .fa {
+    font-size: 25px;
+  }
+
+  .fa-bars {
+    display: none;
+  }
+
+  @include media-breakpoint-up(sm) {
+    .fa-times,
+    .fa-bars {
+      display: none;
+    }
+  }
+}
 
 .side-bar-sub-header {
   width: calc(100% + 30px);

--- a/templates/select_dish.html
+++ b/templates/select_dish.html
@@ -16,8 +16,12 @@
     <div>
       <h1>Dinner planner</h1>
       <div class="select-dish container">
-        <div id="sideBarView" class="col-3">
-          <h2>My Dinner</h2>
+        <div id="sideBarView" class="col-xs-12 col-sm-12 col-md-3">
+          <div class="side-bar-header">
+            <h2>My Dinner</h2>
+            <i class="fa fa-bars"></i>
+            <i class="fa fa-times"></i>
+          </div>
           <div class="people-container">
             <span>People</span>
             <div class="people-selector-button">
@@ -42,18 +46,18 @@
 
           <div id="totalPrice"></div>
 
-          <button id="confirmationButton" class="btn">
+          <button id="confirmationButton" class="btn btn-orange">
             <span>Confirm Dinner</span>
           </button>
         </div>
 
-        <div id="dishSearchView" class="col-9">
+        <div id="dishSearchView" class="col-xs-12 col-sm-12 col-md-9">
           <div class="search-bar">
               <h2>Find a dish</h2>
               <div class="search-bar-container">
                 <input id="keywordInput" placeholder="Enter key word"></input>
                 <select id="dishTypeSelect"></select>
-                <button type="submit" id="searchDishButton">Search</button>
+                <button type="submit" id="searchDishButton" class="btn btn-orange">Search</button>
             </div>
           </div>
           <div class="dish-items-container" id="dishItemsView">


### PR DESCRIPTION
@Envl I have imported FontAwesome (see https://fontawesome.com/) because they have cool icons.

One of the requirements for Lab 1 was that on the Select Dish page the dinner overview panel (what on desktop is the side bar) should be made collapsible. 
If you take a look at templates/select_dish.html you see that I added the following two lines:
```
            <i class="fa fa-bars"></i>
            <i class="fa fa-times"></i>
```
If the panel is collapsed, the fa-bars should show.
If the panel is expanded, the fa-times should show.
This could be fixed by toggling in-line style on the respective DOM nodes: display: none; if you want to hide it and display: block; if you want to show it.

Could you try to make this work?
This example could maybe give you a few hints: https://codepen.io/CreativeJuiz/pen/oCBxz